### PR TITLE
add verification for BPMN_LINT_RULES_PATH

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -58,6 +58,11 @@ async function copyCustomRules(customRules) {
         else if (!fs.lstatSync(customRules).isDirectory()) {
             throw new Error(`The path '${customRules}' is not a directory.`);
         }
+        // Ensure the BPMN_LINT_RULES_PATH directory exists before copying
+        if (!fs.existsSync(BPMN_LINT_RULES_PATH)) {
+            console.log(`The path '${BPMN_LINT_RULES_PATH}' does not exist. Creating directory...`);
+            fs.mkdirSync(BPMN_LINT_RULES_PATH, { recursive: true });
+        }
         const textBlue = "\x1b[34m";
         const customRulesFiles = fs.readdirSync(customRules, 'utf-8');
         console.log(`${textBlue}Copying custom rules to ${BPMN_LINT_RULES_PATH}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,12 @@ async function copyCustomRules(customRules: string) {
             throw new Error(`The path '${customRules}' is not a directory.`);
         }
 
+        // Ensure the BPMN_LINT_RULES_PATH directory exists before copying
+        if (!fs.existsSync(BPMN_LINT_RULES_PATH)) {
+            console.log(`The path '${BPMN_LINT_RULES_PATH}' does not exist. Creating directory...`);
+            fs.mkdirSync(BPMN_LINT_RULES_PATH, {recursive: true});
+        }
+
         const textBlue = "\x1b[34m";
         const customRulesFiles = fs.readdirSync(customRules, 'utf-8');
         console.log(`${textBlue}Copying custom rules to ${BPMN_LINT_RULES_PATH}`);


### PR DESCRIPTION
Fixed a bug where the application would crash if BPMN_LINT_RULES_PATH was not present.